### PR TITLE
handle Cloudflare record already existing by claiming to have created it ourselves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.12.6
+  - 2.12.7
 
 env:
   global:

--- a/build.sbt
+++ b/build.sbt
@@ -1,90 +1,33 @@
-javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
-
 lazy val commonSettings = Seq(
   organization := "Dwolla",
   homepage := Option(url("https://stash.dwolla.net/projects/OPS/repos/cloudflare-public-hostname-lambda")),
-  scalacOptions ++= Seq(
-    "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
-    "-encoding", "utf-8",                // Specify character encoding used by source files.
-    "-explaintypes",                     // Explain type errors in more detail.
-    "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
-    "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
-    "-language:experimental.macros",     // Allow macro definition (besides implementation and application)
-    "-language:higherKinds",             // Allow higher-kinded types
-    "-language:implicitConversions",     // Allow definition of implicit functions called views
-    "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
-    "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-    "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-    "-Xfuture",                          // Turn on future language features.
-    "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-    "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
-    "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
-    "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
-    "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-    "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
-    "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-    "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
-    "-Xlint:option-implicit",            // Option.apply used implicit view.
-    "-Xlint:package-object-classes",     // Class or object defined in package object.
-    "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
-    "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
-    "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
-    "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-    "-Xlint:unsound-match",              // Pattern match may not be typesafe.
-    "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-    "-Ypartial-unification",             // Enable partial unification in type constructor inference
-    "-Ywarn-dead-code",                  // Warn when dead code is identified.
-    "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-    "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
-    "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
-    "-Ywarn-numeric-widen",              // Warn when numerics are widened.
-    "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
-//    "-Xlog-implicits",                 // normally left disabled because it's super noisy
-  ) ++ (scalaBinaryVersion.value match {
-    case "2.12" ⇒ Seq(
-      "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-      "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
-      "-Ywarn-unused:explicits",           // Warn if an explicit parameter is unused.
-      "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
-      "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
-      "-Ywarn-unused:locals",              // Warn if a local definition is unused.
-      "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
-      "-Ywarn-unused:privates",            // Warn if a private member is unused.
-    )
-    case _ ⇒ Seq.empty
-  }),
-  scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
-  scalacOptions in Compile in Test -= "-Xfatal-warnings",
-  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6"),
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),
 )
 
 lazy val specs2Version = "4.3.0"
-lazy val awsSdkVersion = "1.11.354"
-lazy val scalaAwsUtilsVersion = "1.6.1"
+lazy val awsSdkVersion = "1.11.475"
 
-lazy val root = (project in file("."))
+lazy val `cloudflare-public-hostname-lambda` = (project in file("."))
   .settings(
     name := "cloudflare-public-hostname-lambda",
     resolvers ++= Seq(
       Resolver.bintrayRepo("dwolla", "maven")
     ),
     libraryDependencies ++= {
+      val fs2AwsVersion = "1.3.0"
+
       Seq(
         "com.dwolla" %% "scala-cloudformation-custom-resource" % "2.1.0",
-        "com.dwolla" %% "fs2-aws" % "1.0.1",
+        "com.dwolla" %% "fs2-aws" % fs2AwsVersion,
         "io.circe" %% "circe-fs2" % "0.9.0",
-        "com.dwolla" %% "cloudflare-api-client" % "3.0.1",
-        "org.http4s" %% "http4s-blaze-client" % "0.18.15",
+        "com.dwolla" %% "cloudflare-api-client" % "4.0.0-M4",
+        "org.http4s" %% "http4s-blaze-client" % "0.18.21",
         "com.amazonaws" % "aws-java-sdk-kms" % awsSdkVersion,
         "org.apache.httpcomponents" % "httpclient" % "4.5.2",
         "org.specs2" %% "specs2-core" % specs2Version % Test,
         "org.specs2" %% "specs2-mock" % specs2Version % Test,
         "org.specs2" %% "specs2-matcher-extra" % specs2Version % Test,
         "com.dwolla" %% "testutils-specs2" % "1.11.0" % Test exclude("ch.qos.logback", "logback-classic"),
-        "com.dwolla" %% "fs2-aws-testkit" % "1.0.1" % Test,
+        "com.dwolla" %% "fs2-aws-testkit" % fs2AwsVersion % Test,
       )
     },
     updateOptions := updateOptions.value.withCachedResolution(false),
@@ -99,6 +42,8 @@ lazy val stack: Project = (project in file("stack"))
   .settings(
     resolvers ++= Seq(Resolver.jcenterRepo),
     libraryDependencies ++= {
+      val scalaAwsUtilsVersion = "1.6.1"
+
       Seq(
         "com.monsanto.arch" %% "cloud-formation-template-generator" % "3.5.4",
         "org.specs2" %% "specs2-core" % specs2Version % "test,it",
@@ -106,17 +51,10 @@ lazy val stack: Project = (project in file("stack"))
         "com.dwolla" %% "scala-aws-utils" % scalaAwsUtilsVersion % IntegrationTest,
       )
     },
-    stackName := (name in root).value,
-//    changeSetName := {
-//      val pattern = "(.+)-SNAPSHOT$".r
-//      (version in root).value match {
-//        case v@pattern(_) ⇒ Option(s"Revision-$v")
-//        case v ⇒ Option(s"Revision-$v-SNAPSHOT")
-//      }
-//    },
+    stackName := (name in `cloudflare-public-hostname-lambda`).value,
     stackParameters := List(
-      "S3Bucket" → (s3Bucket in root).value,
-      "S3Key" → (s3Key in root).value
+      "S3Bucket" → (s3Bucket in `cloudflare-public-hostname-lambda`).value,
+      "S3Key" → (s3Key in `cloudflare-public-hostname-lambda`).value
     ),
     awsAccountId := sys.props.get("AWS_ACCOUNT_ID"),
     awsRoleName := Option("cloudformation/deployer/cloudformation-deployer"),
@@ -128,7 +66,7 @@ lazy val stack: Project = (project in file("stack"))
   .configs(IntegrationTest)
   .settings(Defaults.itSettings: _*)
   .enablePlugins(CloudFormationStack)
-  .dependsOn(root)
+  .dependsOn(`cloudflare-public-hostname-lambda`)
 
 assemblyMergeStrategy in assembly := {
   case PathList(ps @ _*) if ps.last == "Log4j2Plugins.dat" => sbtassembly.Log4j2MergeStrategy.plugincache

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.1
+sbt.version = 1.2.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 addSbtPlugin("com.dwolla.sbt" %% "sbt-s3-publisher" % "1.2.0")
 addSbtPlugin("com.dwolla.sbt" %% "sbt-cloudformation-stack" % "1.2.2")
+addSbtPlugin("com.dwolla.sbt" %% "sbt-dwolla-base" % "1.2.0")
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.1")
 addSbtPlugin("com.dwolla" % "sbt-assembly-log4j2" % "1.0.0-0e5d5dd98c4c1e12ff7134536456679069c13e4d")
 

--- a/src/main/scala/com/dwolla/lambda/cloudflare/record/CloudflareDnsRecordHandler.scala
+++ b/src/main/scala/com/dwolla/lambda/cloudflare/record/CloudflareDnsRecordHandler.scala
@@ -9,6 +9,7 @@ import cats.data._
 import cats.effect._
 import cats.implicits._
 import com.dwolla.cloudflare._
+import com.dwolla.cloudflare.domain.model.Exceptions.RecordAlreadyExists
 import com.dwolla.cloudflare.domain.model._
 import com.dwolla.fs2aws.kms.KmsDecrypter
 import com.dwolla.lambda.cloudflare.record.CloudflareDnsRecordHandler.parseRecordFrom
@@ -142,10 +143,17 @@ object UpdateCloudflare {
       _ ← warnIfNoIdWasProvidedButDnsRecordExisted(cloudformationProvidedPhysicalResourceId, maybeIdentifiedDnsRecord)
     } yield createOrUpdateToHandlerResponse(createOrUpdate, maybeIdentifiedDnsRecord)
 
+  /*_*/
   private def createRecord(implicit cloudflare: DnsRecordClient[IO]): Kleisli[Stream[IO, ?], UnidentifiedDnsRecord, CreateOrUpdate[IdentifiedDnsRecord]] =
-    for {
-      identifiedRecord ← Kleisli[Stream[IO, ?], UnidentifiedDnsRecord, IdentifiedDnsRecord](unidentifiedDnsRecord ⇒ cloudflare.createDnsRecord(unidentifiedDnsRecord))
-    } yield Create(identifiedRecord)
+    Kleisli { unidentifiedDnsRecord =>
+      for {
+        identifiedRecord <- cloudflare.createDnsRecord(unidentifiedDnsRecord).recoverWith {
+          case RecordAlreadyExists =>
+            cloudflare.getExistingDnsRecords(unidentifiedDnsRecord.name, Option(unidentifiedDnsRecord.content), Option(unidentifiedDnsRecord.recordType))
+        }
+      } yield Create(identifiedRecord)
+    }
+  /*_*/
 
   private def updateRecord(existingRecord: IdentifiedDnsRecord)(implicit cloudflare: DnsRecordClient[IO]): Kleisli[Stream[IO, ?], UnidentifiedDnsRecord, CreateOrUpdate[IdentifiedDnsRecord]] =
     for {
@@ -184,11 +192,12 @@ object UpdateCloudflare {
 
   /*_*/
   private def assertRecordTypeWillNotChange(existingRecordType: String): Kleisli[Stream[IO, ?], UnidentifiedDnsRecord, UnidentifiedDnsRecord] =
-    Kleisli(unidentifiedDnsRecord ⇒
+    Kleisli { unidentifiedDnsRecord =>
       if (unidentifiedDnsRecord.recordType == existingRecordType)
         Stream.emit(unidentifiedDnsRecord)
       else
-        Stream.raiseError(DnsRecordTypeChange(existingRecordType, unidentifiedDnsRecord.recordType)))
+        Stream.raiseError(DnsRecordTypeChange(existingRecordType, unidentifiedDnsRecord.recordType))
+    }
   /*_*/
 
   case class DnsRecordTypeChange(existingRecordType: String, newRecordType: String)

--- a/src/main/scala/com/dwolla/lambda/cloudflare/record/CloudflareDnsRecordHandler.scala
+++ b/src/main/scala/com/dwolla/lambda/cloudflare/record/CloudflareDnsRecordHandler.scala
@@ -98,7 +98,7 @@ object UpdateCloudflare {
   private def handleDelete(physicalResourceId: String)
                           (implicit cloudflare: DnsRecordClient[IO]): Stream[IO, HandlerResponse] = {
     for {
-      existingRecord ← cloudflare.getExistingDnsRecord(physicalResourceId)
+      existingRecord ← cloudflare.getByUri(physicalResourceId)
       deleted ← cloudflare.deleteDnsRecord(existingRecord.physicalResourceId)
     } yield {
       val data = Map(
@@ -117,7 +117,7 @@ object UpdateCloudflare {
   private def handleCreateOrUpdateNonCNAME(unidentifiedDnsRecord: UnidentifiedDnsRecord, cloudformationProvidedPhysicalResourceId: Stream[IO, String])
                                           (implicit cloudflare: DnsRecordClient[IO]): Stream[IO, HandlerResponse] = {
     for {
-      maybeExistingRecord ← cloudformationProvidedPhysicalResourceId.flatMap(cloudflare.getExistingDnsRecord).last
+      maybeExistingRecord ← cloudformationProvidedPhysicalResourceId.flatMap(cloudflare.getByUri).last
       createOrUpdate ← maybeExistingRecord.fold(createRecord)(updateRecord).run(unidentifiedDnsRecord)
     } yield createOrUpdateToHandlerResponse(createOrUpdate, maybeExistingRecord)
   }

--- a/src/main/scala/com/dwolla/lambda/cloudflare/record/package.scala
+++ b/src/main/scala/com/dwolla/lambda/cloudflare/record/package.scala
@@ -2,8 +2,12 @@ package com.dwolla.lambda.cloudflare
 
 import com.dwolla.cloudflare.domain.model.UnidentifiedDnsRecord
 import io.circe._
+import shapeless.tag.@@
+import cats.syntax.contravariant._
 
 package object record {
+  implicit def TaggedStringEncoder[B]: Encoder[String @@ B] = Encoder[String].narrow
+
   implicit val decodeUnidentifiedDnsRecord: Decoder[UnidentifiedDnsRecord] = (c: HCursor) ⇒
     for {
       name ← c.downField("Name").as[String]


### PR DESCRIPTION
Right now a request to create a record of a type other than `CNAME` will fail because Cloudflare refuses to create a duplicate and instead returns an error. Since the extant record matches what we want it to be, instead of failing, this will return the physical resource ID to CloudFormation as if it was actually created here.